### PR TITLE
fix: build without react plugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
-// https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  esbuild: {
+    jsx: 'automatic',
+  },
 });


### PR DESCRIPTION
## Summary
- drop @vitejs/plugin-react requirement
- configure Vite to transform JSX automatically

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b625324de48328af6dc0bc0715a3b6