### PR TITLE
Ensure map fills viewport without scrolling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,8 @@ import RelationshipMap from './components/RelationshipMap';
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
-      <div className="max-w-7xl mx-auto">
-        <RelationshipMap />
-      </div>
+    <div className="h-screen w-screen overflow-hidden bg-gray-100">
+      <RelationshipMap />
     </div>
   );
 }

--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -388,7 +388,7 @@ export default function RelationshipMap() {
   return (
     <div
       ref={containerRef}
-      className="w-full h-screen md:h-[720px] relative bg-stone-200 rounded-2xl overflow-hidden"
+      className="w-full h-full relative bg-stone-200 rounded-2xl overflow-hidden"
       onClick={() => setFocused(null)}
     >
       {/* Header */}

--- a/src/index.css
+++ b/src/index.css
@@ -6,4 +6,5 @@
 /* optional: make the app fill the viewport */
 html, body, #root {
   height: 100%;
+  overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- Prevent scrolling by hiding page overflow and sizing the root container to the viewport
- Let `RelationshipMap` expand to its parent instead of using fixed screen heights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6500e91a083289b74a61ca95c88d9