### PR TITLE
feat: make API URL configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,12 +30,22 @@ cd relationship-map
 npm install
 ```
 
-3. Start the development server:
+3. In a separate terminal, start the API server:
+```bash
+npm run server
+```
+
+4. Start the front-end development server:
 ```bash
 npm run dev
 ```
 
-4. Open your browser and navigate to `http://localhost:5173`
+5. Open your browser and navigate to `http://localhost:5173`
+
+> The front end expects API requests to be sent to the URL specified in the
+> `VITE_API_URL` environment variable. When running locally the default is
+> `http://localhost:3000`, but you can override this by exporting
+> `VITE_API_URL` before starting `npm run dev`.
 
 ## Usage
 

--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -26,7 +26,10 @@ const avatarPool = [
 ];
 const randomAvatar = () => avatarPool[Math.floor(Math.random() * avatarPool.length)];
 
-const API_URL = "http://localhost:3000";
+// Base URL for API calls. Can be overridden with Vite's `VITE_API_URL` env var.
+// Falls back to relative paths when not provided so the frontend can talk to a
+// colocated backend in production environments.
+const API_URL = (import.meta.env.VITE_API_URL || "").replace(/\/$/, "");
 const API_HEADERS = {
   "Content-Type": "application/json",
   Authorization: "Bearer dev-key",


### PR DESCRIPTION
## Summary
- allow API base URL to be configured via `VITE_API_URL` env var
- document separate API server startup and env config in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b65c449f448328a4e1393d28c8f5c2