### PR TITLE
feat: store data in mongo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "vite": "^5.4.0"
   },
   "dependencies": {
-    "sqlite3": "^5.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "mongodb": "^6.8.0"
   }
 }


### PR DESCRIPTION
## Summary
- replace SQLite storage with MongoDB in the API server
- seed initial data into MongoDB from data.json
- add MongoDB driver dependency

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/mongodb)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ff366e748328af4e84432f527edd