### PR TITLE
Persist map data to JSON and stabilize avatars

### DIFF
--- a/data.json
+++ b/data.json
@@ -6,16 +6,97 @@
     "main": { "label": "The Main Guy", "color": "#9B7DFF" }
   },
   "nodes": [
-    { "id": "main", "label": "The Main Guy", "group": "main", "x": 400, "y": 340, "r": 56, "description": "" },
-    { "id": "t1", "label": "Ari", "group": "team", "x": 160, "y": 145, "description": "" },
-    { "id": "t2", "label": "Moe", "group": "team", "x": 230, "y": 170, "description": "" },
-    { "id": "t3", "label": "Ned", "group": "team", "x": 300, "y": 160, "description": "" },
-    { "id": "t4", "label": "Lee", "group": "team", "x": 90, "y": 240, "description": "" },
-    { "id": "p1", "label": "Ivy", "group": "planters", "x": 660, "y": 210, "description": "" },
-    { "id": "p2", "label": "Bud", "group": "planters", "x": 700, "y": 340, "description": "" },
-    { "id": "s1", "label": "Ada", "group": "scientists", "x": 220, "y": 520, "description": "" },
-    { "id": "s2", "label": "Bo", "group": "scientists", "x": 120, "y": 620, "description": "" },
-    { "id": "s3", "label": "Cy", "group": "scientists", "x": 360, "y": 610, "description": "" }
+    {
+      "id": "main",
+      "label": "The Main Guy",
+      "group": "main",
+      "x": 400,
+      "y": 340,
+      "r": 56,
+      "description": "",
+      "avatar": "/avatars/main-guy.jpeg"
+    },
+    {
+      "id": "t1",
+      "label": "Ari",
+      "group": "team",
+      "x": 160,
+      "y": 145,
+      "description": "",
+      "avatar": "/avatars/ari.jpeg"
+    },
+    {
+      "id": "t2",
+      "label": "Moe",
+      "group": "team",
+      "x": 230,
+      "y": 170,
+      "description": "",
+      "avatar": "/avatars/moe.jpeg"
+    },
+    {
+      "id": "t3",
+      "label": "Ned",
+      "group": "team",
+      "x": 300,
+      "y": 160,
+      "description": "",
+      "avatar": "/avatars/ned.jpeg"
+    },
+    {
+      "id": "t4",
+      "label": "Lee",
+      "group": "team",
+      "x": 90,
+      "y": 240,
+      "description": "",
+      "avatar": "/avatars/lee.jpeg"
+    },
+    {
+      "id": "p1",
+      "label": "Ivy",
+      "group": "planters",
+      "x": 660,
+      "y": 210,
+      "description": "",
+      "avatar": "/avatars/ivy.jpeg"
+    },
+    {
+      "id": "p2",
+      "label": "Bud",
+      "group": "planters",
+      "x": 700,
+      "y": 340,
+      "description": "",
+      "avatar": "/avatars/bud.jpeg"
+    },
+    {
+      "id": "s1",
+      "label": "Ada",
+      "group": "scientists",
+      "x": 220,
+      "y": 520,
+      "description": "",
+      "avatar": "/avatars/ada.jpeg"
+    },
+    {
+      "id": "s2",
+      "label": "Bo",
+      "group": "scientists",
+      "x": 120,
+      "y": 620,
+      "description": "",
+      "avatar": "/avatars/bo.jpeg"
+    },
+    {
+      "id": "s3",
+      "label": "Cy",
+      "group": "scientists",
+      "x": 360,
+      "y": 610,
+      "description": "",
+      "avatar": "/avatars/cy.jpeg"
+    }
   ],
   "links": [
     { "id": "l1", "source": "t1", "target": "main", "type": "dashed" },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "express": "^4.18.2",
-    "mongodb": "^6.19.0"
+    "express": "^4.18.2"
   }
 }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,55 +1,126 @@
-const fs = require('fs').promises;
+const fs = require('fs/promises');
 const path = require('path');
-const { MongoClient } = require('mongodb');
 
 const DATA_PATH = path.join(__dirname, '..', 'data.json');
-const MONGO_URI =
-  process.env.MONGO_URI ||
-  'mongodb+srv://ncimenian12345_db_user:sBa3awsGFBhALWJN@cluster0.et8ozd5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
+
+const DEFAULT_DATA = {
+  groups: {
+    team: { label: 'The Team', color: '#5B8DEF' },
+    planters: { label: 'The Planters', color: '#44C4A1' },
+    scientists: { label: 'The Scientists', color: '#FF9171' },
+    main: { label: 'The Main Guy', color: '#9B7DFF' },
+  },
+  nodes: [
+    {
+      id: 'main',
+      label: 'The Main Guy',
+      group: 'main',
+      x: 400,
+      y: 340,
+      r: 56,
+      description: '',
+      avatar: '/avatars/main-guy.jpeg',
+    },
+    {
+      id: 't1',
+      label: 'Ari',
+      group: 'team',
+      x: 160,
+      y: 145,
+      description: '',
+      avatar: '/avatars/ari.jpeg',
+    },
+    {
+      id: 't2',
+      label: 'Moe',
+      group: 'team',
+      x: 230,
+      y: 170,
+      description: '',
+      avatar: '/avatars/moe.jpeg',
+    },
+    {
+      id: 't3',
+      label: 'Ned',
+      group: 'team',
+      x: 300,
+      y: 160,
+      description: '',
+      avatar: '/avatars/ned.jpeg',
+    },
+    {
+      id: 't4',
+      label: 'Lee',
+      group: 'team',
+      x: 90,
+      y: 240,
+      description: '',
+      avatar: '/avatars/lee.jpeg',
+    },
+    {
+      id: 'p1',
+      label: 'Ivy',
+      group: 'planters',
+      x: 660,
+      y: 210,
+      description: '',
+      avatar: '/avatars/ivy.jpeg',
+    },
+    {
+      id: 'p2',
+      label: 'Bud',
+      group: 'planters',
+      x: 700,
+      y: 340,
+      description: '',
+      avatar: '/avatars/bud.jpeg',
+    },
+    {
+      id: 's1',
+      label: 'Ada',
+      group: 'scientists',
+      x: 220,
+      y: 520,
+      description: '',
+      avatar: '/avatars/ada.jpeg',
+    },
+    {
+      id: 's2',
+      label: 'Bo',
+      group: 'scientists',
+      x: 120,
+      y: 620,
+      description: '',
+      avatar: '/avatars/bo.jpeg',
+    },
+    {
+      id: 's3',
+      label: 'Cy',
+      group: 'scientists',
+      x: 360,
+      y: 610,
+      description: '',
+      avatar: '/avatars/cy.jpeg',
+    },
+  ],
+  links: [
+    { id: 'l1', source: 't1', target: 'main', type: 'dashed' },
+    { id: 'l2', source: 't3', target: 'main', type: 'dashed' },
+    { id: 'l3', source: 't4', target: 's2', type: 'solid' },
+    { id: 'l4', source: 'p1', target: 'main', type: 'curved' },
+    { id: 'l5', source: 'p2', target: 'main', type: 'curved' },
+    { id: 'l6', source: 's1', target: 's2', type: 'solid' },
+    { id: 'l7', source: 's1', target: 'main', type: 'dashed' },
+  ],
+};
 
 async function main() {
-  const raw = await fs.readFile(DATA_PATH, 'utf8');
-  const data = JSON.parse(raw);
-
-  const client = new MongoClient(MONGO_URI);
-  await client.connect();
-  const db = client.db('relationshipMap');
-  const nodes = db.collection('nodes');
-  const links = db.collection('links');
-
-  await nodes.deleteMany({});
-  await links.deleteMany({});
-
-  if (data.nodes && data.nodes.length) {
-    await nodes.insertMany(
-      data.nodes.map((n) => ({
-        id: n.id,
-        label: n.label,
-        group: n.group,
-        x: n.x,
-        y: n.y,
-        description: n.description || '',
-        avatar: n.avatar || null,
-      }))
-    );
-  }
-
-  if (data.links && data.links.length) {
-    await links.insertMany(
-      data.links.map((l) => ({
-        id: l.id,
-        source: l.source,
-        target: l.target,
-        type: l.type || 'solid',
-      }))
-    );
-  }
-
-  await client.close();
+  const payload = JSON.stringify(DEFAULT_DATA, null, 2);
+  await fs.writeFile(DATA_PATH, `${payload}\n`);
+  console.log(`Seeded ${DATA_PATH} with default relationship data.`);
 }
 
 main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
-

--- a/server.js
+++ b/server.js
@@ -1,10 +1,10 @@
 const express = require('express');
-const { MongoClient } = require('mongodb');
+const fs = require('fs/promises');
+const path = require('path');
+
 const app = express();
 
-const MONGO_URI =
-  process.env.MONGO_URI ||
-  'mongodb+srv://ncimenian12345_db_user:sBa3awsGFBhALWJN@cluster0.et8ozd5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
+const DATA_FILE = path.join(__dirname, 'data.json');
 const API_KEY = process.env.API_KEY || 'dev-key';
 
 app.use(express.json());
@@ -27,71 +27,234 @@ function auth(req, res, next) {
 
 app.use(auth);
 
-let nodesCollection;
-let linksCollection;
-
-async function initDb() {
-  const client = new MongoClient(MONGO_URI);
-  await client.connect();
-  const db = client.db('relationshipMap');
-  nodesCollection = db.collection('nodes');
-  linksCollection = db.collection('links');
-  await nodesCollection.createIndex({ id: 1 }, { unique: true });
-  await linksCollection.createIndex({ id: 1 }, { unique: true });
+class HttpError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+  }
 }
 
-app.get('/map', async (req, res) => {
-  const nodes = await nodesCollection.find({}, { projection: { _id: 0 } }).toArray();
-  const links = await linksCollection.find({}, { projection: { _id: 0 } }).toArray();
-  res.json({ nodes, links });
+let state = { groups: {}, nodes: [], links: [] };
+let persistQueue = Promise.resolve();
+
+const toFiniteNumber = (value) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+};
+
+const sanitizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+function normalizeNode(node) {
+  const id = sanitizeString(node?.id ?? '');
+  const label = sanitizeString(node?.label ?? '');
+  const group = sanitizeString(node?.group ?? '');
+  const x = toFiniteNumber(node?.x);
+  const y = toFiniteNumber(node?.y);
+  if (!id || !label || !group || x === null || y === null) {
+    return null;
+  }
+  const normalized = {
+    id,
+    label,
+    group,
+    x,
+    y,
+    description: typeof node?.description === 'string' ? node.description : '',
+  };
+  const r = toFiniteNumber(node?.r);
+  if (r !== null) {
+    normalized.r = r;
+  }
+  if (typeof node?.avatar === 'string' && node.avatar.trim()) {
+    normalized.avatar = node.avatar.trim();
+  }
+  return normalized;
+}
+
+function normalizeLink(link) {
+  const id = sanitizeString(link?.id ?? '');
+  const source = sanitizeString(link?.source ?? '');
+  const target = sanitizeString(link?.target ?? '');
+  if (!id || !source || !target) {
+    return null;
+  }
+  const type = sanitizeString(link?.type ?? '') || 'solid';
+  return { id, source, target, type };
+}
+
+function normalizeState(raw) {
+  const groups = raw && typeof raw.groups === 'object' && raw.groups !== null ? raw.groups : {};
+  const nodes = Array.isArray(raw?.nodes)
+    ? raw.nodes.map(normalizeNode).filter(Boolean)
+    : [];
+  const links = Array.isArray(raw?.links)
+    ? raw.links.map(normalizeLink).filter(Boolean)
+    : [];
+  return { groups, nodes, links };
+}
+
+async function writeState(next) {
+  const payload = JSON.stringify(next, null, 2);
+  await fs.writeFile(DATA_FILE, `${payload}\n`);
+  state = next;
+}
+
+function enqueueMutation(mutator) {
+  let result;
+  const op = persistQueue
+    .catch((err) => {
+      console.error('Previous persistence operation failed', err);
+    })
+    .then(async () => {
+      const { next, value } = await mutator(state);
+      if (!next || typeof next !== 'object') {
+        throw new Error('Mutation must return an object with a `next` state');
+      }
+      await writeState(next);
+      result = value;
+    });
+  persistQueue = op;
+  return op.then(() => result);
+}
+
+async function loadState() {
+  try {
+    const raw = await fs.readFile(DATA_FILE, 'utf8');
+    const parsed = JSON.parse(raw);
+    state = normalizeState(parsed);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+      state = { groups: {}, nodes: [], links: [] };
+      await writeState(state);
+    } else {
+      console.error('Failed to load data file', err);
+      throw err;
+    }
+  }
+}
+
+app.get('/map', (req, res) => {
+  res.json(state);
 });
 
 app.post('/nodes', async (req, res) => {
-  const { id, label, group, x, y, description = '', avatar = null } = req.body || {};
-  if (!id || !label || !group || typeof x !== 'number' || typeof y !== 'number') {
+  const { id, label, group, x, y, description = '', avatar = null, r = null } = req.body || {};
+  if (
+    typeof id !== 'string' ||
+    typeof label !== 'string' ||
+    typeof group !== 'string' ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y)
+  ) {
     return res.status(400).json({ error: 'id, label, group, x, y required' });
   }
+  const trimmedId = id.trim();
+  const trimmedLabel = label.trim();
+  const trimmedGroup = group.trim();
+  if (!trimmedId || !trimmedLabel || !trimmedGroup) {
+    return res.status(400).json({ error: 'id, label, group must be non-empty strings' });
+  }
+  const node = {
+    id: trimmedId,
+    label: trimmedLabel,
+    group: trimmedGroup,
+    x,
+    y,
+    description: typeof description === 'string' ? description : '',
+  };
+  if (typeof avatar === 'string' && avatar.trim()) {
+    node.avatar = avatar.trim();
+  }
+  if (Number.isFinite(r)) {
+    node.r = r;
+  }
   try {
-    await nodesCollection.insertOne({ id, label, group, x, y, description, avatar });
+    await enqueueMutation((current) => {
+      if (current.nodes.some((n) => n.id === node.id)) {
+        throw new HttpError(409, 'Node exists');
+      }
+      return {
+        next: {
+          ...current,
+          nodes: [...current.nodes, node],
+        },
+      };
+    });
     res.status(201).json({ ok: true });
   } catch (err) {
-    if (err && err.code === 11000) {
-      return res.status(409).json({ error: 'Node exists' });
+    if (err instanceof HttpError) {
+      return res.status(err.status).json({ error: err.message });
     }
-    throw err;
+    console.error('Failed to save node', err);
+    res.status(500).json({ error: 'Failed to save node' });
   }
 });
 
 app.post('/links', async (req, res) => {
   const { id, source, target, type = 'solid' } = req.body || {};
-  if (!id || !source || !target) {
+  if (typeof id !== 'string' || typeof source !== 'string' || typeof target !== 'string') {
+    return res.status(400).json({ error: 'id, source, target required' });
+  }
+  const link = {
+    id: id.trim(),
+    source: source.trim(),
+    target: target.trim(),
+    type: typeof type === 'string' && type.trim() ? type.trim() : 'solid',
+  };
+  if (!link.id || !link.source || !link.target) {
     return res.status(400).json({ error: 'id, source, target required' });
   }
   try {
-    await linksCollection.insertOne({ id, source, target, type });
+    await enqueueMutation((current) => {
+      if (current.links.some((l) => l.id === link.id)) {
+        throw new HttpError(409, 'Link exists');
+      }
+      return {
+        next: {
+          ...current,
+          links: [...current.links, link],
+        },
+      };
+    });
     res.status(201).json({ ok: true });
   } catch (err) {
-    if (err && err.code === 11000) {
-      return res.status(409).json({ error: 'Link exists' });
+    if (err instanceof HttpError) {
+      return res.status(err.status).json({ error: err.message });
     }
-    throw err;
+    console.error('Failed to save link', err);
+    res.status(500).json({ error: 'Failed to save link' });
   }
 });
 
 app.patch('/nodes/:id', async (req, res) => {
-  const { description = '' } = req.body || {};
-  const result = await nodesCollection.updateOne(
-    { id: req.params.id },
-    { $set: { description } }
-  );
-  if (result.matchedCount === 0) {
-    return res.status(404).json({ error: 'Node not found' });
+  const description = typeof req.body?.description === 'string' ? req.body.description : '';
+  try {
+    await enqueueMutation((current) => {
+      const idx = current.nodes.findIndex((n) => n.id === req.params.id);
+      if (idx === -1) {
+        throw new HttpError(404, 'Node not found');
+      }
+      const nodes = current.nodes.slice();
+      nodes[idx] = { ...nodes[idx], description };
+      return {
+        next: {
+          ...current,
+          nodes,
+        },
+      };
+    });
+    res.json({ ok: true });
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return res.status(err.status).json({ error: err.message });
+    }
+    console.error('Failed to update node', err);
+    res.status(500).json({ error: 'Failed to update node' });
   }
-  res.json({ ok: true });
 });
 
 async function start() {
-  await initDb();
+  await loadState();
   const port = process.env.PORT || 3000;
   app.listen(port, () => console.log(`API running on port ${port}`));
 }


### PR DESCRIPTION
## Summary
- replace the Mongo-backed API with a lightweight file-backed store that serialises nodes and links to `data.json`
- give all built-in characters fixed avatar assignments and ensure loaded data is normalised before hitting the UI
- update the seed script and dependencies now that no external database is required

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc620cd57483288d022a83439ad38b