### PR TITLE
Persist relationship map data in MongoDB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "express": "^4.18.2",
+        "mongodb": "^5.9.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.18",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "mongodb": "^5.9.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -30,17 +30,30 @@ cd relationship-map
 npm install
 ```
 
-3. In a separate terminal, start the API server:
+3. (Optional) Seed the MongoDB database with the demo content:
+```bash
+npm run seed
+```
+
+4. Configure the API server environment variables (defaults are shown below):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `API_KEY` | `dev-key` | Shared bearer token used by the frontend when calling the API |
+| `MONGODB_URI` | MongoDB Atlas connection string in `server.js` | Connection string for the relationship-map database |
+| `MONGODB_DB` | `relationship-map` | Database name that stores `groups`, `nodes`, and `links` |
+
+5. In a separate terminal, start the API server:
 ```bash
 npm run server
 ```
 
-4. Start the front-end development server:
+6. Start the front-end development server:
 ```bash
 npm run dev
 ```
 
-5. Open your browser and navigate to `http://localhost:5173`
+7. Open your browser and navigate to `http://localhost:5173`
 
 > The front end expects API requests to be sent to the URL specified in the
 > `VITE_API_URL` environment variable. When running locally the default is


### PR DESCRIPTION
## Summary
- replace the file-based API storage with a MongoDB client, helper utilities, and route handlers that read and write the database directly
- add the MongoDB driver dependency and update the seeding script to populate the `groups`, `nodes`, and `links` collections with sanitized demo content
- document the optional seeding step and MongoDB-related environment variables required to run the API server locally

## Testing
- npm install *(fails: registry requests return HTTP 403 because the environment blocks npm registry access)*
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd78cbd2d08328a95f0e9edbfc26e3