### PR TITLE
Set production API base URL to Vercel deployment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,9 @@ npm run dev
 > The front end expects API requests to be sent to the URL specified in the
 > `VITE_API_URL` environment variable. When running locally the default is
 > `http://localhost:3000`, but you can override this by exporting
-> `VITE_API_URL` before starting `npm run dev`.
+> `VITE_API_URL` before starting `npm run dev`. Production builds default to
+> `https://relationship-map.vercel.app` when no environment override is
+> provided.
 
 ## Usage
 

--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -40,7 +40,10 @@ const resolveAvatar = (node) => {
 // When no env var is provided we default to the local API during dev builds so
 // `npm run dev` Just Works. In production we fall back to relative URLs so a
 // colocated backend (same origin) continues to work without configuration.
-const rawApiBase = (import.meta.env.VITE_API_URL || (import.meta.env.DEV ? "http://localhost:3000" : "")).trim();
+const rawApiBase = (
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.DEV ? "http://localhost:3000" : "https://relationship-map.vercel.app")
+).trim();
 const API_URL = rawApiBase.replace(/\/$/, "");
 const apiUrl = (path) => `${API_URL}${path}`;
 const API_HEADERS = {


### PR DESCRIPTION
## Summary
- default the production API base URL to https://relationship-map.vercel.app when no env override is provided
- update the README to document the production default

## Testing
- npm install *(fails: 403 Forbidden from npm registry in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9363a9a083288b37d04204ea8d94