### PR TITLE
Update MongoDB connection string

### DIFF
--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,6 +1,8 @@
 const { MongoClient } = require('mongodb');
 
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017';
+const MONGODB_URI =
+  process.env.MONGODB_URI ||
+  'mongodb+srv://Vercel-Admin-relationship-map:zgivlkrP37H67Opj@relationship-map.sxtr2sd.mongodb.net/?retryWrites=true&w=majority&appName=relationship-map';
 const MONGODB_DB = process.env.MONGODB_DB || 'relationship-map';
 
 const DEFAULT_DATA = {

--- a/server.js
+++ b/server.js
@@ -4,7 +4,9 @@ const { MongoClient } = require('mongodb');
 const app = express();
 
 const API_KEY = process.env.API_KEY || 'dev-key';
-const MONGODB_URI = process.env.MONGODB_URI || 'mongodb://127.0.0.1:27017';
+const MONGODB_URI =
+  process.env.MONGODB_URI ||
+  'mongodb+srv://Vercel-Admin-relationship-map:zgivlkrP37H67Opj@relationship-map.sxtr2sd.mongodb.net/?retryWrites=true&w=majority&appName=relationship-map';
 const MONGODB_DB = process.env.MONGODB_DB || 'relationship-map';
 
 app.use(express.json());


### PR DESCRIPTION
## Summary
- update the Express server configuration to default to the new MongoDB Atlas connection string
- update the database seeding script to use the same MongoDB Atlas connection string when no environment override is provided

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda306dc5c83288d21f845e7ddd1f5