### PR TITLE
Improve MongoDB connectivity diagnostics and client handling

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,0 +1,148 @@
+const { MongoClient, ServerApiVersion } = require('mongodb');
+
+const MONGODB_URI =
+  process.env.MONGODB_URI ||
+  'mongodb+srv://Vercel-Admin-relationship-map:zgivlkrP37H67Opj@relationship-map.sxtr2sd.mongodb.net/?retryWrites=true&w=majority&appName=relationship-map';
+const MONGODB_DB = process.env.MONGODB_DB || 'relationship-map';
+
+let cachedClient = null;
+let connectPromise = null;
+
+function createClient() {
+  return new MongoClient(MONGODB_URI, {
+    serverApi: {
+      version: ServerApiVersion.v1,
+      strict: false,
+      deprecationErrors: true,
+    },
+  });
+}
+
+function isClientUsable(client) {
+  return !!client && !!client.topology && !client.topology.isDestroyed();
+}
+
+async function resetClient() {
+  if (cachedClient) {
+    try {
+      await cachedClient.close();
+    } catch (err) {
+      // ignore close errors so we can recreate the client
+    }
+  }
+  cachedClient = null;
+  connectPromise = null;
+}
+
+async function getClient() {
+  if (isClientUsable(cachedClient)) {
+    return cachedClient;
+  }
+  if (!connectPromise) {
+    cachedClient = createClient();
+    connectPromise = cachedClient
+      .connect()
+      .catch(async (err) => {
+        await resetClient();
+        throw err;
+      });
+  }
+  await connectPromise;
+  return cachedClient;
+}
+
+function shouldResetForError(err) {
+  if (!err) return false;
+  const transientNames = new Set([
+    'MongoNetworkError',
+    'MongoNotConnectedError',
+    'MongoServerSelectionError',
+    'MongoTopologyClosedError',
+    'MongoTimeoutError',
+  ]);
+  if (transientNames.has(err.name)) {
+    return true;
+  }
+  const msg = typeof err.message === 'string' ? err.message.toLowerCase() : '';
+  if (!msg) return false;
+  return (
+    msg.includes('server selection timed out') ||
+    msg.includes('topology was destroyed') ||
+    msg.includes('connection closed')
+  );
+}
+
+async function getCollections() {
+  try {
+    const client = await getClient();
+    const db = client.db(MONGODB_DB);
+    return {
+      client,
+      db,
+      groups: db.collection('groups'),
+      nodes: db.collection('nodes'),
+      links: db.collection('links'),
+    };
+  } catch (err) {
+    if (shouldResetForError(err)) {
+      await resetClient();
+      const client = await getClient();
+      const db = client.db(MONGODB_DB);
+      return {
+        client,
+        db,
+        groups: db.collection('groups'),
+        nodes: db.collection('nodes'),
+        links: db.collection('links'),
+      };
+    }
+    throw err;
+  }
+}
+
+async function runWithRetry(operation) {
+  let lastError;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const collections = await getCollections();
+      return await operation(collections);
+    } catch (err) {
+      lastError = err;
+      if (shouldResetForError(err) && attempt === 0) {
+        await resetClient();
+        continue;
+      }
+      break;
+    }
+  }
+  throw lastError;
+}
+
+async function pingDatabase() {
+  return runWithRetry(async ({ db }) => {
+    await db.command({ ping: 1 });
+    const [groupsCount, nodesCount, linksCount] = await Promise.all([
+      db.collection('groups').estimatedDocumentCount(),
+      db.collection('nodes').estimatedDocumentCount(),
+      db.collection('links').estimatedDocumentCount(),
+    ]);
+    return {
+      ok: true,
+      database: MONGODB_DB,
+      groupsCount,
+      nodesCount,
+      linksCount,
+    };
+  });
+}
+
+module.exports = {
+  getCollections,
+  runWithRetry,
+  pingDatabase,
+  resetClient,
+  constants: {
+    MONGODB_URI,
+    MONGODB_DB,
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "preview": "vite preview",
     "test": "echo \"No tests yet\" && exit 0",
     "server": "node server.js",
-    "seed": "node scripts/seed.js"
+    "seed": "node scripts/seed.js",
+    "diagnose": "node scripts/diagnose.js"
   },
   "devDependencies": {
     "tailwindcss": "^3.4.0",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,12 @@ npm run dev
 
 5. Open your browser and navigate to `http://localhost:5173`
 
+6. (Optional) Run the connectivity diagnostic to confirm the API can talk to MongoDB:
+```bash
+npm run diagnose
+```
+This command pings the configured database, prints sample records, and performs a temporary write/delete cycle to validate CRUD access.
+
 > The front end expects API requests to be sent to the URL specified in the
 > `VITE_API_URL` environment variable. When running locally the default is
 > `http://localhost:3000`, but you can override this by exporting
@@ -49,6 +55,13 @@ npm run dev
 > `VITE_API_URL` to be set to the deployed Express API origin (e.g.
 > `https://relationship-map-api.vercel.app`) before running `npm run build` or
 > deploying.
+
+### Environment variables
+
+- `API_KEY`: Shared secret required by the Express API. Defaults to `dev-key` during development.
+- `MONGODB_URI` / `MONGODB_DB`: Connection string and database name used by the API and helper scripts.
+- `VITE_API_URL`: Base URL of the deployed Express API consumed by the React front end.
+- `VITE_API_KEY`: API key sent by the front end. Defaults to `dev-key` when developing locally; set it in production to mirror `API_KEY`.
 
 ## Usage
 

--- a/scripts/diagnose.js
+++ b/scripts/diagnose.js
@@ -1,0 +1,49 @@
+const { pingDatabase, runWithRetry, resetClient } = require('../lib/mongo');
+
+async function main() {
+  console.log('Running MongoDB connectivity diagnostic...');
+  const status = await pingDatabase();
+  console.log(
+    `✔ Ping successful. Database "${status.database}" currently has ${status.nodesCount} nodes and ${status.linksCount} links.`
+  );
+
+  const sampleNodes = await runWithRetry(async ({ nodes }) =>
+    nodes
+      .find({}, { projection: { _id: 1, label: 1, group: 1 } })
+      .sort({ _id: 1 })
+      .limit(5)
+      .toArray()
+  );
+  if (sampleNodes.length === 0) {
+    console.log('ℹ No nodes found in the collection.');
+  } else {
+    console.log('ℹ Sample nodes:', sampleNodes);
+  }
+
+  const diagnosticsId = `diagnostic_${Date.now()}`;
+  await runWithRetry(async ({ nodes }) =>
+    nodes.insertOne({
+      _id: diagnosticsId,
+      label: 'Diagnostics Check',
+      group: 'diagnostics',
+      x: 0,
+      y: 0,
+      description: 'Temporary document inserted by diagnostics script.',
+    })
+  );
+  console.log('✔ Write check succeeded. Temporary diagnostics node inserted.');
+
+  await runWithRetry(async ({ nodes }) => nodes.deleteOne({ _id: diagnosticsId }));
+  console.log('✔ Cleanup succeeded. Temporary diagnostics node removed.');
+
+  console.log('Diagnostics complete. MongoDB connectivity looks healthy.');
+}
+
+main()
+  .catch((err) => {
+    console.error('Diagnostics failed:', err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    resetClient().catch(() => {});
+  });


### PR DESCRIPTION
## Summary
- centralize MongoDB access in a shared helper with retry logic, add a health endpoint, and improve startup logging
- add a MongoDB diagnostics script, update the seed script to share the helper, and document required environment variables
- allow configuring the front-end API key via `VITE_API_KEY` and surface a clear fallback message when the API is unreachable

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d04463c55c8328942564de13f8f508