### PR TITLE
Allow production builds without VITE_API_URL

### DIFF
--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -51,10 +51,16 @@ const rawApiBase = (() => {
   if (envApiUrl) {
     return envApiUrl;
   }
-  const message =
-    "Missing VITE_API_URL environment variable. Set it to your deployed Express API origin before building.";
-  console.error(message);
-  throw new Error(message);
+  if (typeof window !== "undefined" && window.location && window.location.origin) {
+    console.warn(
+      "VITE_API_URL is not set. Falling back to the current origin for API requests. Configure VITE_API_URL for production deployments."
+    );
+    return window.location.origin;
+  }
+  console.warn(
+    "VITE_API_URL is not set and the current origin cannot be determined. API requests will use relative paths."
+  );
+  return "";
 })();
 const API_URL = rawApiBase.replace(/\/$/, "");
 const normalizeApiPath = (path = "") => {


### PR DESCRIPTION
## Summary
- fall back to the current origin when VITE_API_URL is not provided in production builds so the UI can still render
- warn that relative URLs will be used if the origin cannot be determined instead of throwing during module initialization

## Testing
- `npm install` *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0494dc6d48328a1b00747541eb2ea