### PR TITLE
Fix loadMap dependency ReferenceError

### DIFF
--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -363,6 +363,7 @@ const Edge = ({ a, b, type = "solid", highlight = false }) => {
 export default function RelationshipMap() {
   const [data, setData] = useState({ groups: {}, nodes: [], links: [] });
   const [focused, setFocused] = useState(null);
+  const [lastError, setLastError] = useState("");
   const containerRef = useRef(null);
   const { transform, events, setView, limits } = usePanZoom({ initial: 1, min: 0.5, max: 2.5 });
   const persistedAvatarById = useRef(new Map());
@@ -542,7 +543,6 @@ export default function RelationshipMap() {
   // Add Node / Link state & helpers
   const [newNode, setNewNode] = useState({ label: "", group: "team", description: "" });
   const [newLink, setNewLink] = useState({ source: "", target: "", type: "solid" });
-  const [lastError, setLastError] = useState("");
   const [focusedNotes, setFocusedNotes] = useState("");
 
   const slug = (s) => (s || "").toLowerCase().trim().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");


### PR DESCRIPTION
## Summary
- initialize the `lastError` state before defining hooks that depend on it
- prevent runtime ReferenceErrors when the dependency array references the state setter

## Testing
- npm install *(fails: registry access forbidden in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d04f05a9b8832899eef62407287703