### PR TITLE
Normalize API base URLs for production domain

### DIFF
--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -82,7 +82,26 @@ const BASE_API_HEADERS = {
 
 const sanitizeBase = (value) => {
   if (typeof value !== "string") return "";
-  return value.trim().replace(/\/+$/, "");
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) || trimmed.startsWith("//")) {
+    return trimmed.replace(/\/+$/, "");
+  }
+  if (trimmed.startsWith("/")) {
+    const normalized = `/${trimmed.replace(/^\/+/, "")}`;
+    return normalized.replace(/\/+$/, "");
+  }
+  const lower = trimmed.toLowerCase();
+  const isLocalHost = /^localhost(?::|\/|\?|#|$)/.test(lower);
+  const isIpAddress = /^\d+\.\d+\.\d+\.\d+(?::\d+)?(?:\/|$)/.test(trimmed);
+  const looksLikeHost = trimmed.includes(".") || trimmed.includes(":") || isLocalHost || isIpAddress;
+  if (!looksLikeHost) {
+    const normalized = `/${trimmed.replace(/^\/+/, "")}`;
+    return normalized.replace(/\/+$/, "");
+  }
+  const hasExplicitPort = /:\d+/.test(trimmed);
+  const scheme = isLocalHost || isIpAddress || hasExplicitPort ? "http" : "https";
+  return `${scheme}://${trimmed}`.replace(/\/+$/, "");
 };
 
 const API_BASE_CANDIDATES = (() => {


### PR DESCRIPTION
## Summary
- normalize API base URLs by auto-applying a default scheme so bare domains like `relationshipsmaps.com` resolve to HTTPS
- keep support for localhost, IP addresses, explicit ports, and relative paths when building the candidate base list

## Testing
- npm run build *(fails: vite is unavailable because dependencies could not be installed in this environment)*
- npm install *(fails: registry access returns HTTP 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d23466a4088328a34e8a5df874bff2