### PR TITLE
Add production API key configuration

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=https://relationship-map-api.vercel.app
+VITE_API_KEY=dev-key


### PR DESCRIPTION
## Summary
- add the shared API key to `.env.production` so production builds send the expected Authorization header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d23a31a4d08328adcee8f1a5ed8bb5