### PR TITLE
Update legend styles and ensure all nodes connect

### DIFF
--- a/data.json
+++ b/data.json
@@ -99,12 +99,14 @@
     }
   ],
   "links": [
-    { "id": "l1", "source": "t1", "target": "main", "type": "dashed" },
-    { "id": "l2", "source": "t3", "target": "main", "type": "dashed" },
+    { "id": "l1", "source": "t1", "target": "main", "type": "trust" },
+    { "id": "l2", "source": "t3", "target": "main", "type": "trust" },
     { "id": "l3", "source": "t4", "target": "s2", "type": "solid" },
-    { "id": "l4", "source": "p1", "target": "main", "type": "curved" },
-    { "id": "l5", "source": "p2", "target": "main", "type": "curved" },
+    { "id": "l4", "source": "p1", "target": "main", "type": "mixed" },
+    { "id": "l5", "source": "p2", "target": "main", "type": "mixed" },
     { "id": "l6", "source": "s1", "target": "s2", "type": "solid" },
-    { "id": "l7", "source": "s1", "target": "main", "type": "dashed" }
+    { "id": "l7", "source": "s1", "target": "main", "type": "trust" },
+    { "id": "l8", "source": "t2", "target": "main", "type": "solid" },
+    { "id": "l9", "source": "s3", "target": "s1", "type": "mixed" }
   ]
 }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -103,13 +103,15 @@ const DEFAULT_DATA = {
     },
   ],
   links: [
-    { id: 'l1', source: 't1', target: 'main', type: 'dashed' },
-    { id: 'l2', source: 't3', target: 'main', type: 'dashed' },
+    { id: 'l1', source: 't1', target: 'main', type: 'trust' },
+    { id: 'l2', source: 't3', target: 'main', type: 'trust' },
     { id: 'l3', source: 't4', target: 's2', type: 'solid' },
-    { id: 'l4', source: 'p1', target: 'main', type: 'curved' },
-    { id: 'l5', source: 'p2', target: 'main', type: 'curved' },
+    { id: 'l4', source: 'p1', target: 'main', type: 'mixed' },
+    { id: 'l5', source: 'p2', target: 'main', type: 'mixed' },
     { id: 'l6', source: 's1', target: 's2', type: 'solid' },
-    { id: 'l7', source: 's1', target: 'main', type: 'dashed' },
+    { id: 'l7', source: 's1', target: 'main', type: 'trust' },
+    { id: 'l8', source: 't2', target: 'main', type: 'solid' },
+    { id: 'l9', source: 's3', target: 's1', type: 'mixed' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- add edge type metadata and render the legend with trust issues, mixed feelings, solid terms, and focus highlight labels
- update edge drawing to honor the new styles and keep highlight behavior consistent
- refresh fallback and seed link data so every default node has at least one connection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2c719ef7483288fa64ba824503f6f