### PR TITLE
Rename main character to Noah and add default narratives

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,19 +1,19 @@
 {
   "groups": {
-    "team": { "label": "The Team", "color": "#5B8DEF" },
-    "planters": { "label": "The Planters", "color": "#44C4A1" },
-    "scientists": { "label": "The Scientists", "color": "#FF9171" },
-    "main": { "label": "The Main Guy", "color": "#9B7DFF" }
+    "team": { "label": "Competitors", "color": "#5B8DEF" },
+    "planters": { "label": "Suppliers", "color": "#44C4A1" },
+    "scientists": { "label": "Manufacturers", "color": "#FF9171" },
+    "main": { "label": "Noah", "color": "#9B7DFF" }
   },
   "nodes": [
     {
       "id": "main",
-      "label": "The Main Guy",
+      "label": "Noah",
       "group": "main",
       "x": 400,
       "y": 340,
       "r": 56,
-      "description": "",
+      "description": "Noah-The ice seller who keeps the whole network running. Without him, Bud and Ivy wouldn't have a reason to supply ice, and ADA, Cy, Bo, and Lee wouldn't be moving as much product from the manufacturing side. He's at the center of the supply chain, managing deals, negotiating with suppliers, and figuring out how to stay ahead of competitors like Moe, Ari, and Ned.",
       "avatar": "/avatars/main-guy.jpeg"
     },
     {
@@ -22,7 +22,7 @@
       "group": "team",
       "x": 160,
       "y": 145,
-      "description": "",
+      "description": "Ari - Ari runs a rival ice operation and loves to brag about outselling Noah, which drives Noah crazy; their rivalry fuels most of Noah's motivation to outdo everyone else.",
       "avatar": "/avatars/ari.jpeg"
     },
     {
@@ -31,7 +31,7 @@
       "group": "team",
       "x": 230,
       "y": 170,
-      "description": "",
+      "description": "Mo - Noah and Moe are best friends, but their friendship is complicated by business — Moe is technically Noah's competitor, running his own ice business on the other side of town. They respect each other's hustle but quietly keep an eye on each other's moves.",
       "avatar": "/avatars/moe.jpeg"
     },
     {
@@ -40,7 +40,7 @@
       "group": "team",
       "x": 300,
       "y": 160,
-      "description": "",
+      "description": "Ned- Ned is another competitor who once tried to poach Noah's best supplier, leaving Noah furious and determined never to trust him again.",
       "avatar": "/avatars/ned.jpeg"
     },
     {
@@ -49,7 +49,7 @@
       "group": "team",
       "x": 90,
       "y": 240,
-      "description": "",
+      "description": "Lee - Bo and Lee are inseparable co-workers who grew up learning the trade together, and they have a reputation for getting shipments out faster than anyone else.",
       "avatar": "/avatars/lee.jpeg"
     },
     {
@@ -58,7 +58,7 @@
       "group": "planters",
       "x": 660,
       "y": 210,
-      "description": "",
+      "description": "Ivy - Ivy is another supplier for Noah, and while their working relationship is polite, Noah wishes Ivy were more open and collaborative about new ideas.",
       "avatar": "/avatars/ivy.jpeg"
     },
     {
@@ -67,7 +67,7 @@
       "group": "planters",
       "x": 700,
       "y": 340,
-      "description": "",
+      "description": "Bud - Noah relies on Bud as one of his main suppliers, and though they're only casually friendly, Noah appreciates that Bud always delivers on time and keeps things professional.",
       "avatar": "/avatars/bud.jpeg"
     },
     {
@@ -76,7 +76,7 @@
       "group": "scientists",
       "x": 220,
       "y": 520,
-      "description": "",
+      "description": "Ada - Noah has bad blood with ADA, one of the manufacturers — she once shorted him on a shipment and publicly called him out over it, so he refuses to work with her unless absolutely necessary.",
       "avatar": "/avatars/ada.jpeg"
     },
     {
@@ -85,7 +85,7 @@
       "group": "scientists",
       "x": 120,
       "y": 620,
-      "description": "",
+      "description": "Bo - Ada and Bo are best friends on the manufacturing floor, often teaming up to solve problems and gossip about the sellers' drama.",
       "avatar": "/avatars/bo.jpeg"
     },
     {
@@ -94,7 +94,7 @@
       "group": "scientists",
       "x": 360,
       "y": 610,
-      "description": "",
+      "description": "Cy - Ada and Cy work together as part of the manufacturing team, exchanging casual banter on the job but mostly focusing on production.",
       "avatar": "/avatars/cy.jpeg"
     }
   ],

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -4,20 +4,21 @@ const { MONGODB_DB } = constants;
 
 const DEFAULT_DATA = {
   groups: {
-    team: { label: 'The Team', color: '#5B8DEF' },
-    planters: { label: 'The Planters', color: '#44C4A1' },
-    scientists: { label: 'The Scientists', color: '#FF9171' },
-    main: { label: 'The Main Guy', color: '#9B7DFF' },
+    team: { label: 'Competitors', color: '#5B8DEF' },
+    planters: { label: 'Suppliers', color: '#44C4A1' },
+    scientists: { label: 'Manufacturers', color: '#FF9171' },
+    main: { label: 'Noah', color: '#9B7DFF' },
   },
   nodes: [
     {
       id: 'main',
-      label: 'The Main Guy',
+      label: 'Noah',
       group: 'main',
       x: 400,
       y: 340,
       r: 56,
-      description: '',
+      description:
+        "Noah-The ice seller who keeps the whole network running. Without him, Bud and Ivy wouldn't have a reason to supply ice, and ADA, Cy, Bo, and Lee wouldn't be moving as much product from the manufacturing side. He's at the center of the supply chain, managing deals, negotiating with suppliers, and figuring out how to stay ahead of competitors like Moe, Ari, and Ned.",
       avatar: '/avatars/main-guy.jpeg',
     },
     {
@@ -26,7 +27,8 @@ const DEFAULT_DATA = {
       group: 'team',
       x: 160,
       y: 145,
-      description: '',
+      description:
+        "Ari - Ari runs a rival ice operation and loves to brag about outselling Noah, which drives Noah crazy; their rivalry fuels most of Noah's motivation to outdo everyone else.",
       avatar: '/avatars/ari.jpeg',
     },
     {
@@ -35,7 +37,8 @@ const DEFAULT_DATA = {
       group: 'team',
       x: 230,
       y: 170,
-      description: '',
+      description:
+        "Mo - Noah and Moe are best friends, but their friendship is complicated by business — Moe is technically Noah's competitor, running his own ice business on the other side of town. They respect each other's hustle but quietly keep an eye on each other's moves.",
       avatar: '/avatars/moe.jpeg',
     },
     {
@@ -44,7 +47,8 @@ const DEFAULT_DATA = {
       group: 'team',
       x: 300,
       y: 160,
-      description: '',
+      description:
+        "Ned- Ned is another competitor who once tried to poach Noah's best supplier, leaving Noah furious and determined never to trust him again.",
       avatar: '/avatars/ned.jpeg',
     },
     {
@@ -53,7 +57,8 @@ const DEFAULT_DATA = {
       group: 'team',
       x: 90,
       y: 240,
-      description: '',
+      description:
+        "Lee - Bo and Lee are inseparable co-workers who grew up learning the trade together, and they have a reputation for getting shipments out faster than anyone else.",
       avatar: '/avatars/lee.jpeg',
     },
     {
@@ -62,7 +67,8 @@ const DEFAULT_DATA = {
       group: 'planters',
       x: 660,
       y: 210,
-      description: '',
+      description:
+        "Ivy - Ivy is another supplier for Noah, and while their working relationship is polite, Noah wishes Ivy were more open and collaborative about new ideas.",
       avatar: '/avatars/ivy.jpeg',
     },
     {
@@ -71,7 +77,8 @@ const DEFAULT_DATA = {
       group: 'planters',
       x: 700,
       y: 340,
-      description: '',
+      description:
+        "Bud - Noah relies on Bud as one of his main suppliers, and though they're only casually friendly, Noah appreciates that Bud always delivers on time and keeps things professional.",
       avatar: '/avatars/bud.jpeg',
     },
     {
@@ -80,7 +87,8 @@ const DEFAULT_DATA = {
       group: 'scientists',
       x: 220,
       y: 520,
-      description: '',
+      description:
+        "Ada - Noah has bad blood with ADA, one of the manufacturers — she once shorted him on a shipment and publicly called him out over it, so he refuses to work with her unless absolutely necessary.",
       avatar: '/avatars/ada.jpeg',
     },
     {
@@ -89,7 +97,8 @@ const DEFAULT_DATA = {
       group: 'scientists',
       x: 120,
       y: 620,
-      description: '',
+      description:
+        "Bo - Ada and Bo are best friends on the manufacturing floor, often teaming up to solve problems and gossip about the sellers' drama.",
       avatar: '/avatars/bo.jpeg',
     },
     {
@@ -98,7 +107,8 @@ const DEFAULT_DATA = {
       group: 'scientists',
       x: 360,
       y: 610,
-      description: '',
+      description:
+        "Cy - Ada and Cy work together as part of the manufacturing team, exchanging casual banter on the job but mostly focusing on production.",
       avatar: '/avatars/cy.jpeg',
     },
   ],

--- a/src/components/RelationshipMap.jsx
+++ b/src/components/RelationshipMap.jsx
@@ -212,20 +212,21 @@ const fetchFromApi = async (path, options = {}) => {
 // ---------------- Demo Data (✅ now defined in-file) ----------------
 const demo = {
   groups: {
-    team: { label: "The Team", color: "#5B8DEF" },
-    planters: { label: "The Planters", color: "#44C4A1" },
-    scientists: { label: "The Scientists", color: "#FF9171" },
-    main: { label: "The Main Guy", color: "#9B7DFF" },
+    team: { label: "Competitors", color: "#5B8DEF" },
+    planters: { label: "Suppliers", color: "#44C4A1" },
+    scientists: { label: "Manufacturers", color: "#FF9171" },
+    main: { label: "Noah", color: "#9B7DFF" },
   },
   nodes: [
     {
       id: "main",
-      label: "The Main Guy",
+      label: "Noah",
       group: "main",
       x: 400,
       y: 340,
       r: 56,
-      description: "",
+      description:
+        "Noah-The ice seller who keeps the whole network running. Without him, Bud and Ivy wouldn't have a reason to supply ice, and ADA, Cy, Bo, and Lee wouldn't be moving as much product from the manufacturing side. He's at the center of the supply chain, managing deals, negotiating with suppliers, and figuring out how to stay ahead of competitors like Moe, Ari, and Ned.",
       avatar: defaultAvatarById.main,
     },
     {
@@ -234,7 +235,8 @@ const demo = {
       group: "team",
       x: 160,
       y: 145,
-      description: "",
+      description:
+        "Ari - Ari runs a rival ice operation and loves to brag about outselling Noah, which drives Noah crazy; their rivalry fuels most of Noah's motivation to outdo everyone else.",
       avatar: defaultAvatarById.t1,
     },
     {
@@ -243,7 +245,8 @@ const demo = {
       group: "team",
       x: 230,
       y: 170,
-      description: "",
+      description:
+        "Mo - Noah and Moe are best friends, but their friendship is complicated by business — Moe is technically Noah's competitor, running his own ice business on the other side of town. They respect each other's hustle but quietly keep an eye on each other's moves.",
       avatar: defaultAvatarById.t2,
     },
     {
@@ -252,7 +255,8 @@ const demo = {
       group: "team",
       x: 300,
       y: 160,
-      description: "",
+      description:
+        "Ned- Ned is another competitor who once tried to poach Noah's best supplier, leaving Noah furious and determined never to trust him again.",
       avatar: defaultAvatarById.t3,
     },
     {
@@ -261,7 +265,8 @@ const demo = {
       group: "team",
       x: 90,
       y: 240,
-      description: "",
+      description:
+        "Lee - Bo and Lee are inseparable co-workers who grew up learning the trade together, and they have a reputation for getting shipments out faster than anyone else.",
       avatar: defaultAvatarById.t4,
     },
     {
@@ -270,7 +275,8 @@ const demo = {
       group: "planters",
       x: 660,
       y: 210,
-      description: "",
+      description:
+        "Ivy - Ivy is another supplier for Noah, and while their working relationship is polite, Noah wishes Ivy were more open and collaborative about new ideas.",
       avatar: defaultAvatarById.p1,
     },
     {
@@ -279,7 +285,8 @@ const demo = {
       group: "planters",
       x: 700,
       y: 340,
-      description: "",
+      description:
+        "Bud - Noah relies on Bud as one of his main suppliers, and though they're only casually friendly, Noah appreciates that Bud always delivers on time and keeps things professional.",
       avatar: defaultAvatarById.p2,
     },
     {
@@ -288,7 +295,8 @@ const demo = {
       group: "scientists",
       x: 220,
       y: 520,
-      description: "",
+      description:
+        "Ada - Noah has bad blood with ADA, one of the manufacturers — she once shorted him on a shipment and publicly called him out over it, so he refuses to work with her unless absolutely necessary.",
       avatar: defaultAvatarById.s1,
     },
     {
@@ -297,7 +305,8 @@ const demo = {
       group: "scientists",
       x: 120,
       y: 620,
-      description: "",
+      description:
+        "Bo - Ada and Bo are best friends on the manufacturing floor, often teaming up to solve problems and gossip about the sellers' drama.",
       avatar: defaultAvatarById.s2,
     },
     {
@@ -306,7 +315,8 @@ const demo = {
       group: "scientists",
       x: 360,
       y: 610,
-      description: "",
+      description:
+        "Cy - Ada and Cy work together as part of the manufacturing team, exchanging casual banter on the job but mostly focusing on production.",
       avatar: defaultAvatarById.s3,
     },
   ],
@@ -725,12 +735,15 @@ export default function RelationshipMap() {
   };
 
   // Group labels (positions roughly matching demo)
-  const groupLabels = useMemo(() => ({
-    team: { x: 210, y: 100, label: "The Team" },
-    planters: { x: 550, y: 140, label: "The Planters" },
-    scientists: { x: 260, y: 470, label: "The Scientists" },
-    main: { x: 350, y: 260, label: "The Main Guy" },
-  }), []);
+  const groupLabels = useMemo(
+    () => ({
+      team: { x: 210, y: 100, label: "Competitors" },
+      planters: { x: 550, y: 140, label: "Suppliers" },
+      scientists: { x: 260, y: 470, label: "Manufacturers" },
+      main: { x: 350, y: 260, label: "Noah" },
+    }),
+    []
+  );
 
   // Add Node / Link state & helpers
   const [newNode, setNewNode] = useState({ label: "", group: "team", description: "" });


### PR DESCRIPTION
## Summary
- rename the main character to Noah and retitle the legend categories to Competitors, Suppliers, and Manufacturers
- seed the bundled data with the supplied backstories so the notes panel is pre-populated across the UI and database seed

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2ded577c08328a5eaa7fd93da3e7f